### PR TITLE
Livescript: Works a bit

### DIFF
--- a/boxy.html
+++ b/boxy.html
@@ -28,6 +28,7 @@
     <script src="modules/markdown/markdown.js"> </script>
     <script src="modules/llm-infer/llm-infer.js"> </script>
     <script src="modules/save-restore/save-restore.js"> </script>
+    <script src="modules/livescript/livescript.js"> </script>
 
   </body>
 </html>

--- a/boxy.js
+++ b/boxy.js
@@ -1027,12 +1027,14 @@ function setCursorPosition(position) {
   moveCursorTo(position.node, position.offset);
 }
 
-function statusLedOn() {
+function statusLedOn(engine_name = null) {
   document.getElementById('status-led').classList.add('running');
+  if (engine_name) document.getElementById('status-led').classList.add(engine_name);
 }
 
-function statusLedOff() {
+function statusLedOff(engine_name = null) {
   document.getElementById('status-led').classList.remove('running');
+  if (engine_name) document.getElementById('status-led').classList.remove(engine_name);
 }
 
 // Add event listeners

--- a/boxy.js
+++ b/boxy.js
@@ -650,22 +650,22 @@ function handleKeydown(event) {
 
     // Check if the key is in the key map
     if (keyMap[key]) {
-      keyMap[key](); // Execute the mapped function
       event.preventDefault();
+      keyMap[key](); // Execute the mapped function
     } else if (event.ctrlKey) {
       // Handle unbound Ctrl combinations
+      event.preventDefault();
       console.log(`Unbound Ctrl combination: ${key}`);
       showUnboundKeyAlert(key);
-      event.preventDefault();
     } else if (/^[\x20-\x7E\t]$/.test(event.key)) {
       // Handle self-inserting characters (printable ASCII including space and tab)
-      insertCharAtCursor(event.key);
       event.preventDefault();
+      insertCharAtCursor(event.key);
     } else {
       // Show alert for other unbound special keys
+      event.preventDefault();
       console.log(`Unbound key: ${key}`);
       showUnboundKeyAlert(key);
-      event.preventDefault();
     }
   } catch (e) {
     showError(e.message);

--- a/modules/livescript/livescript.js
+++ b/modules/livescript/livescript.js
@@ -3,38 +3,109 @@
 // evaluate box as JavaScript and stick results in a context.
 // Security Risks: human-preview the script in the box before pressing the execute button.
 
-const global_livescripts = {};
+// 1. Create a sandbox that optionally inherits from a parent sandbox.
+function BoxSandbox(parentSandbox) {
+  // Create a new object whose prototype is the parent's sandbox (if any).
+  return Object.create(parentSandbox || {});
+}
 
-function addMethodsToObj(element, targetObj) {
-  const scriptText = element.textContent;
-  console.log(`Evaluating JavaScript: ${scriptText}`);
-
-  try {
-    console.log(`before: global_livescripts=${global_livescripts}`);
-    with(global_livescripts) {
-      eval(scriptText);
+// 2. Locate the nearest ancestor box with an existing sandbox.
+// Assumes your box elements have the CSS class "box".
+function getParentSandbox(box) {
+  let parent = box.parentNode;
+  while (parent) {
+    if (parent.classList &&
+        parent.classList.contains('box') &&
+        parent.sandbox) {
+      return parent.sandbox;
     }
-    console.log(`after: global_livescripts=${global_livescripts}`);
-
-  } catch (error) {
-    console.error(`Error evaluating JavaScript: ${error.message}`);
-    throw error;
+    parent = parent.parentNode;
   }
+  return null;
 }
 
-function evaluateCurrentBox() {
-  evaluateBox(cursor.parentNode);
+// 3. Evaluate code in a temporary iframe and capture all new global bindings.
+//    The new bindings are copied into the provided sandbox.
+function evaluateCodeInSandbox(code, sandbox) {
+  // Create a hidden iframe.
+  const iframe = document.createElement("iframe");
+  iframe.style.display = "none";
+  document.body.appendChild(iframe);
+
+  // Access the iframe's global object.
+  const win = iframe.contentWindow;
+
+  // Capture the baseline set of global properties before evaluating the code.
+  const baseline = new Set(Object.keys(win));
+
+  // Evaluate the code in the iframe's global context.
+  // (Assumes non‑strict mode so that top‑level function declarations attach to win.)
+  let result = win.eval(code);
+
+  // Copy every new global property from the iframe's window into the sandbox.
+  Object.keys(win).forEach(function(key) {
+    if (!baseline.has(key)) {
+      sandbox[key] = win[key];
+    }
+  });
+
+  // Clean up by removing the iframe.
+  document.body.removeChild(iframe);
+
+  // return result
+  return result;
 }
 
+// 4. Attach sandbox methods as properties on the box element.
+//    (This makes it convenient to call them later, e.g. box.foo().)
+function addMethodsToObj(box, sandbox) {
+  Object.keys(sandbox).forEach(function(key) {
+    if (typeof sandbox[key] === 'function') {
+      box[key] = sandbox[key];
+    }
+  });
+}
+
+// 5. Evaluate a box's code.
+//    - If the box already has a sandbox, reuse it.
+//    - Otherwise, create a new sandbox (with a link to its parent's sandbox).
+//    - Then, evaluate the code and capture any new bindings.
 function evaluateBox(box) {
-  if (!box || !box.textContent) return;
+  if (!box || !box.textContent.trim()) return;
   statusLedOn('livescript');
+  let result = "";
 
   try {
-    addMethodsToObj(box, global_livescripts); 
+    // Look for a parent's sandbox for inheritance.
+    const parentSandbox = getParentSandbox(box);
+
+    // Reuse the existing sandbox if available; otherwise, create a new one.
+    if (!box.sandbox) {
+      box.sandbox = new BoxSandbox(parentSandbox);
+    }
+
+    // Retrieve the code from the box element.
+    const code = box.textContent;
+
+    // Evaluate the code in a temporary iframe, copying new bindings into box.sandbox.
+    result = evaluateCodeInSandbox(code, box.sandbox);
+
+    // Copy functions from the sandbox to the box element for easy access.
+    addMethodsToObj(box, box.sandbox);
+  } catch (err) {
+    console.error("Error evaluating box:", err);
   } finally {
     statusLedOff('livescript');
   }
+  return String(result);
 }
 
+// 6. Evaluate the box containing the current cursor.
+function evaluateCurrentBox() {
+  let response = evaluateBox(cursor.parentNode);
+  exitBoxRight();
+  insertLlmResponse(response);
+}
+
+// 7. Map a keyboard shortcut to evaluate the current box.
 keyMap['Ctrl-='] = evaluateCurrentBox;

--- a/modules/livescript/livescript.js
+++ b/modules/livescript/livescript.js
@@ -1,0 +1,40 @@
+// modules/livescript/livescript.js
+
+// evaluate box as JavaScript and stick results in a context.
+// Security Risks: human-preview the script in the box before pressing the execute button.
+
+const global_livescripts = {};
+
+function addMethodsToObj(element, targetObj) {
+  const scriptText = element.textContent;
+  console.log(`Evaluating JavaScript: ${scriptText}`);
+
+  try {
+    console.log(`before: global_livescripts=${global_livescripts}`);
+    with(global_livescripts) {
+      eval(scriptText);
+    }
+    console.log(`after: global_livescripts=${global_livescripts}`);
+
+  } catch (error) {
+    console.error(`Error evaluating JavaScript: ${error.message}`);
+    throw error;
+  }
+}
+
+function evaluateCurrentBox() {
+  evaluateBox(cursor.parentNode);
+}
+
+function evaluateBox(box) {
+  if (!box || !box.textContent) return;
+  statusLedOn('livescript');
+
+  try {
+    addMethodsToObj(box, global_livescripts); 
+  } finally {
+    statusLedOff('livescript');
+  }
+}
+
+keyMap['Ctrl-='] = evaluateCurrentBox;

--- a/modules/llm-infer/llm-infer.js
+++ b/modules/llm-infer/llm-infer.js
@@ -104,7 +104,7 @@ function killResponse() {
 }
 
 async function llmInfer() {
-  statusLedOn();
+  statusLedOn('llm');
   killResponse();
 
   let question = getCurrentRowText();
@@ -118,10 +118,10 @@ async function llmInfer() {
     const response = await callOpenAPI(messages, "instruct", 0.7, 1.0, 0.0, 42);
     console.log("llmInfer response", JSON.stringify(response));
     insertLlmResponse(response);
-    document.getElementById('status-led').classList.remove('running');
+    statusLedOff('llm')
   } catch (error) {
     console.error("Error during inference:", error);
-    statusLedOff();
+    statusLedOff('llm');        // todo red to fade
     throw new Error("Failed to get LLM response. Please try again.", error);
   }
 
@@ -129,7 +129,7 @@ async function llmInfer() {
 
 // todo: use open api chat history instead of just string concat
 async function llmChat() {
-  statusLedOn();
+  statusLedOn('llm');
   let history_raw = getBoxRowsText(cursor.parentNode);
   console.log("llmChat history_raw", JSON.stringify(history_raw));
   let chatHistory = constructChatHistory(history_raw);
@@ -137,7 +137,7 @@ async function llmChat() {
   const response = await callOpenAPI(chatHistory, "chat", 0.7, 1.0, 0.0, 42);
   console.log("llmChat response", JSON.stringify(response));
   insertLlmResponse(response);
-  statusLedOff();
+  statusLedOff('llm');
 }
 
 function moveCursorToEndOfLine(parentNode) {

--- a/style.css
+++ b/style.css
@@ -98,7 +98,19 @@ div.box.markdown li::marker {
   background-color: transparent;
 }
 
-#status-led.running {
+#status-led.running.llm {
   background-color: green;
+}
+
+#status-led.running.livescript {
+  background-color: yellow;
+}
+
+#status-led.running.llm:hover::after {
+  content: "LLM";
+}
+
+#status-led.running.livescript:hover::after {
+  content: "Livescript";
 }
 


### PR DESCRIPTION
- https://chatgpt.com/c/67a11fdd-4ad8-800c-b7ce-2978af814f70
- scoping of parent boxes untested
- need to separate definition and evaluation, maybe by being explicit about sandbox open/close and separate key for eval
- do we need a livescript box type that controls this behavior?
- 